### PR TITLE
Allow faker globally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
+gem 'faker'
 
 gem 'fast_jsonapi'
 group :development, :test do
@@ -32,7 +33,6 @@ group :development, :test do
   gem 'capybara'
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
-  gem 'faker'
 end
 
 group :development do

--- a/app/controllers/api/v1/medical_professionals_controller.rb
+++ b/app/controllers/api/v1/medical_professionals_controller.rb
@@ -2,9 +2,10 @@ class Api::V1::MedicalProfessionalsController < ApplicationController
   def index
     medical_professionals = MedicalProfessionalsFacade.depict_profession(params[:type], params[:state])
 
-    if params[:type] == 'doctor'
+    case params[:type]
+    when 'doctor'
       render json: DoctorSerializer.new(medical_professionals).serializable_hash
-    elsif params[:type] == 'mhp'
+    when 'mhp'
       render json: MhpSerializer.new(medical_professionals).serializable_hash
     end
   end

--- a/app/facades/medical_professionals_facade.rb
+++ b/app/facades/medical_professionals_facade.rb
@@ -1,17 +1,16 @@
 class MedicalProfessionalsFacade
   class << self
-    
     def depict_profession(type, state)
       care_givers = format_doctors(get_all_vetted_doctors(type, state)) if type == 'doctor'
       care_givers = format_mhp(get_all_vetted_mhp(type, state)) if type == 'mhp'
       OpenStruct.new(id: nil, list: care_givers)
     end
 
-    def get_all_vetted_doctors(type, state)
+    def get_all_vetted_doctors(_type, state)
       Doctor.where(vetted: true, state: state)
     end
 
-    def get_all_vetted_mhp(type, state)
+    def get_all_vetted_mhp(_type, state)
       MentalHealthProfessional.where(vetted: true, state: state)
     end
 

--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -2,7 +2,7 @@ class Doctor < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :state, presence: true
-  validates :vetted, :inclusion => {:in => [true, false]}
+  validates :vetted, inclusion: { in: [true, false] }
 
   has_many :doctor_insurances
   has_many :doctor_specialties

--- a/app/models/mental_health_professional.rb
+++ b/app/models/mental_health_professional.rb
@@ -2,7 +2,7 @@ class MentalHealthProfessional < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :state, presence: true
-  validates :vetted, :inclusion => {:in => [true, false]}
+  validates :vetted, inclusion: { in: [true, false] }
 
   has_many :mhp_insurances
   has_many :mhp_specialties


### PR DESCRIPTION
# Description

@A-McGuire and I had had some complications with Heroku not identifying Faker. We moved it out of any blocks so that it could be identified globally in the gemfile. We also went ahead and linted with rubocop to clean up our codebase a bit.

Fixes # (Uninitialized constant Faker)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
